### PR TITLE
Update 042_create_timeline.php

### DIFF
--- a/application/migrations/042_create_timeline.php
+++ b/application/migrations/042_create_timeline.php
@@ -30,7 +30,7 @@ class Migration_create_timeline extends CI_Migration
             ),
             'date'        => array(
                 'type'    => 'DATE',
-                'default' => false,
+                'default' => 'CURDATE(),
                 'comment' => 'YYYY-MM-DD'
             ),
             'image'       => array(


### PR DESCRIPTION
CMS was not being installed correctly on version 7.4 because MySQL date cant be false.